### PR TITLE
Fix for app freeze on restore while navigation is in progress

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
+        android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="HERE SDK Ref App"
         tools:ignore="AllowBackup">

--- a/android/app/src/main/kotlin/com/example/RefApp/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/RefApp/MainActivity.kt
@@ -19,20 +19,22 @@
 
 package com.example.RefApp
 
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import androidx.core.view.WindowCompat
 import com.example.RefApp.FlutterForegroundService.Companion.START_FOREGROUND_ACTION
 import com.example.RefApp.FlutterForegroundService.Companion.STOP_FOREGROUND_ACTION
 import com.example.RefApp.FlutterForegroundService.Companion.UPDATE_FOREGROUND_ACTION
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     companion object {
+        const val FLUTTER_ENGINE_ID = "refAppFlutterEngine"
         private const val CHANNEL = "com.example.RefApp/foreground_service_channel"
         private const val START_SERVICE = "startService"
         private const val STOP_SERVICE = "stopService"
@@ -106,5 +108,9 @@ class MainActivity : FlutterActivity() {
     private fun stopForegroundService(intent: Intent) {
         intent.action = STOP_FOREGROUND_ACTION
         context.startService(intent)
+    }
+
+    override fun provideFlutterEngine(context: Context): FlutterEngine? {
+        return FlutterEngineCache.getInstance().get(FLUTTER_ENGINE_ID)
     }
 }

--- a/android/app/src/main/kotlin/com/example/RefApp/MainApplication.kt
+++ b/android/app/src/main/kotlin/com/example/RefApp/MainApplication.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.example.RefApp
+
+import android.app.Application;
+
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.embedding.engine.dart.DartExecutor;
+
+class MainApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val flutterEngine = FlutterEngine(this)
+
+        flutterEngine.dartExecutor.executeDartEntrypoint(
+                DartExecutor.DartEntrypoint.createDefault())
+
+        FlutterEngineCache.getInstance().put(MainActivity.FLUTTER_ENGINE_ID, flutterEngine)
+    }
+}

--- a/lib/navigation/navigation_screen.dart
+++ b/lib/navigation/navigation_screen.dart
@@ -682,6 +682,11 @@ class _NavigationScreenState extends State<NavigationScreen> with WidgetsBinding
       SchedulerBinding.instance
           .addPostFrameCallback((timeStamp) => _visualNavigator.startRendering(_hereMapController));
     }
+    if (state == AppLifecycleState.detached) {
+      LocalNotificationsHelper.stopNotifications();
+      _stopNavigation();
+      Navigator.of(context).popUntil((route) => route.settings.name == LandingScreen.navRoute);
+    }
     _appLifecycleState = state;
   }
 }


### PR DESCRIPTION
FlutterEngine is cached and reused if MainActivity is killed (on
Android). If application view is killed during navigation then
background service and navigation are stopped, app also navigates to
landing screen - user will see this screen if app is started again.