### PR TITLE
IOTSDK-15795: Invalid Enum - Grey screen fixed.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - here_sdk (4.13.0.0.10160.release):
+  - here_sdk (4.13.0.0.10129.rc4):
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
@@ -77,7 +77,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_tts: 0f492aab6accf87059b72354fcb4ba934304771d
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  here_sdk: eea2d207345686f0e6ac7474c9ecfb9a2e2689ef
+  here_sdk: 30aa3bba79e144781c49e4b0c1da1bef271db25f
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   ringtone_player: 151303fcb26e9daa11257fa6947faed36b198f13
@@ -88,4 +88,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: df55b3ee02a183f44faf3430330ec06ef69f552d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
-  - here_sdk (4.13.0.0.10129.rc4):
+  - here_sdk (4.13.0.0.10160.release):
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
@@ -77,7 +77,7 @@ SPEC CHECKSUMS:
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_tts: 0f492aab6accf87059b72354fcb4ba934304771d
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  here_sdk: 30aa3bba79e144781c49e4b0c1da1bef271db25f
+  here_sdk: eea2d207345686f0e6ac7474c9ecfb9a2e2689ef
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   ringtone_player: 151303fcb26e9daa11257fa6947faed36b198f13
@@ -88,4 +88,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: df55b3ee02a183f44faf3430330ec06ef69f552d
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.11.2

--- a/lib/route_preferences/enum_string_helper.dart
+++ b/lib/route_preferences/enum_string_helper.dart
@@ -18,6 +18,7 @@
  */
 
 import 'dart:collection';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:here_sdk/core.dart';
@@ -186,6 +187,7 @@ class EnumStringHelper {
           result[localizations.dirtRoad] = value;
           break;
         case RoadFeatures.uTurns:
+        case RoadFeatures.difficultTurns:
           result[localizations.uTurns] = value;
           break;
         default:


### PR DESCRIPTION
- Fix grey screen caused by removal of deprecated value.

Signed-off-by: Mohan Sai Manthri <119850631+mohan-manthri@users.noreply.github.com>