### PR TITLE
Fixed on-screen keyboard blocking text fields

### DIFF
--- a/lib/route_preferences/route_preferences_screen.dart
+++ b/lib/route_preferences/route_preferences_screen.dart
@@ -69,7 +69,6 @@ class _RoutePreferencesScreenState extends State<RoutePreferencesScreen> with Ti
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.routePreferencesScreenTitle),
         bottom: PreferredSize(

--- a/lib/route_preferences/truck_specifications_screen.dart
+++ b/lib/route_preferences/truck_specifications_screen.dart
@@ -37,7 +37,6 @@ class TruckSpecificationsScreen extends StatelessWidget {
     AppLocalizations localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
-      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         title: Text(localizations.truckSpecificationsTitle),
       ),


### PR DESCRIPTION
- Resolves an issue where the keyboard was blocking the text fields.
- Fixes the problem by setting the `resizeToAvoidBottomInset` to true. (default)