### PR TITLE
TICKET-T-16950-3: Fix Location permission warning message issue

### DIFF
--- a/lib/positioning/no_location_warning_widget.dart
+++ b/lib/positioning/no_location_warning_widget.dart
@@ -39,6 +39,9 @@ class NoLocationWarning extends StatelessWidget {
   }) : super(key: key);
 
   Future<String> _warningMessage(BuildContext context) async {
+    if (!await Permission.location.serviceStatus.isEnabled) {
+      return AppLocalizations.of(context)!.noLocationWarning;
+    }
     final PermissionStatus locationPermission = await Permission.location.status;
     final PermissionStatus locationAlwaysPermission = await Permission.locationAlways.status;
     if (locationPermission == PermissionStatus.granted && locationAlwaysPermission != PermissionStatus.granted) {


### PR DESCRIPTION
- LocationServices warning message will only be visible per app launch.
- Permissions should get requested when location services enabled, if not already granted.
- Code improvements.