### PR TITLE
TICKET-T-17753:MapDownload will resume after restoring the network connection

### DIFF
--- a/lib/common/connection_state_monitor.dart
+++ b/lib/common/connection_state_monitor.dart
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020-2023 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/material.dart';
+
+import '../download_maps/map_loader_controller.dart';
+
+class ConnectionStateMonitor extends StatefulWidget {
+  const ConnectionStateMonitor({this.child, super.key, required this.mapLoaderController});
+
+  final Widget? child;
+  final MapLoaderController mapLoaderController;
+
+  @override
+  State<ConnectionStateMonitor> createState() => _ConnectionStateMonitorState();
+}
+
+class _ConnectionStateMonitorState extends State<ConnectionStateMonitor> {
+  bool get isConnected => _status != ConnectivityResult.none;
+  ConnectivityResult? _status;
+  late StreamSubscription<ConnectivityResult> _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription = Connectivity().onConnectivityChanged.listen((_) async {
+      // Check latest connectivity status on connection change.
+      final ConnectivityResult status = await Connectivity().checkConnectivity();
+      if (_status != status) {
+        _status = status;
+        if (isConnected) {
+          // Check for any pending downloads and resume
+          widget.mapLoaderController.resumePendingMapDownloads();
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _subscription.cancel();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child!;
+}

--- a/lib/common/connection_state_monitor.dart
+++ b/lib/common/connection_state_monitor.dart
@@ -62,5 +62,5 @@ class _ConnectionStateMonitorState extends State<ConnectionStateMonitor> {
   }
 
   @override
-  Widget build(BuildContext context) => widget.child!;
+  Widget build(BuildContext context) => widget.child;
 }

--- a/lib/common/connection_state_monitor.dart
+++ b/lib/common/connection_state_monitor.dart
@@ -25,9 +25,9 @@ import 'package:flutter/material.dart';
 import '../download_maps/map_loader_controller.dart';
 
 class ConnectionStateMonitor extends StatefulWidget {
-  const ConnectionStateMonitor({this.child, super.key, required this.mapLoaderController});
+  const ConnectionStateMonitor({super.key, required this.child, required this.mapLoaderController});
 
-  final Widget? child;
+  final Widget child;
   final MapLoaderController mapLoaderController;
 
   @override

--- a/lib/download_maps/map_loader_controller.dart
+++ b/lib/download_maps/map_loader_controller.dart
@@ -121,7 +121,7 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
 
   /// Contains list of RegionId which get paused.
   /// return `List<RegionId>`
-  final List<RegionId> _pausedTagsOnBackground = <RegionId>[];
+  final List<RegionId> _pausedRegionsWhenOffline = <RegionId>[];
 
   MapUpdateState _mapUpdateState = MapUpdateState.none;
   int? _mapUpdateProgress;
@@ -187,16 +187,16 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
         [region],
         DownloadRegionsStatusListener((error, regions) {
           _regionsInProgress.remove(region);
-          _pausedTagsOnBackground.remove(region);
+          _pausedRegionsWhenOffline.remove(region);
           notifyListeners();
         }, (id, progress) {
           _regionsInProgress[region]?.progress = progress;
           notifyListeners();
         }, (error) {
-          _pausedTagsOnBackground.add(region);
+          _pausedRegionsWhenOffline.add(region);
           notifyListeners();
         }, () {
-          _pausedTagsOnBackground.remove(region);
+          _pausedRegionsWhenOffline.remove(region);
           notifyListeners();
         }));
 
@@ -255,8 +255,8 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
 
   // Handle pending Map Downloads
   void resumePendingMapDownloads() {
-    if (_pausedTagsOnBackground.isNotEmpty) {
-      _pausedTagsOnBackground.forEach((RegionId region) => _regionsInProgress[region]?.resume());
+    if (_pausedRegionsWhenOffline.isNotEmpty) {
+      _pausedRegionsWhenOffline.forEach((RegionId region) => _regionsInProgress[region]?.resume());
       notifyListeners();
     }
   }

--- a/lib/landing_screen.dart
+++ b/lib/landing_screen.dart
@@ -36,6 +36,7 @@ import 'package:here_sdk/search.dart';
 import 'package:provider/provider.dart';
 
 import 'common/application_preferences.dart';
+import 'common/connection_state_monitor.dart';
 import 'common/custom_map_style_settings.dart';
 import 'common/load_custom_style_result_popup.dart';
 import 'common/place_actions_popup.dart';
@@ -106,22 +107,25 @@ class _LandingScreenState extends State<LandingScreen> with Positioning, Widgets
 
   @override
   Widget build(BuildContext context) {
-    return Consumer2<AppPreferences, CustomMapStyleSettings>(
-      builder: (context, preferences, customStyleSettings, child) => Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: Stack(
-          children: [
-            HereMap(
-              key: _hereMapKey,
-              onMapCreated: _onMapCreated,
-            ),
-            _buildMenuButton(),
-          ],
+    return ConnectionStateMonitor(
+      mapLoaderController: Provider.of<MapLoaderController>(context, listen: false),
+      child: Consumer2<AppPreferences, CustomMapStyleSettings>(
+        builder: (context, preferences, customStyleSettings, child) => Scaffold(
+          resizeToAvoidBottomInset: false,
+          body: Stack(
+            children: [
+              HereMap(
+                key: _hereMapKey,
+                onMapCreated: _onMapCreated,
+              ),
+              _buildMenuButton(),
+            ],
+          ),
+          floatingActionButton: _mapInitSuccess ? _buildFAB(context) : null,
+          drawer: _buildDrawer(context, preferences),
+          extendBodyBehindAppBar: true,
+          onDrawerChanged: (isOpened) => _dismissLocationWarningPopup(),
         ),
-        floatingActionButton: _mapInitSuccess ? _buildFAB(context) : null,
-        drawer: _buildDrawer(context, preferences),
-        extendBodyBehindAppBar: true,
-        onDrawerChanged: (isOpened) => _dismissLocationWarningPopup(),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b502a681ba415272ecc41400bd04fe543ed1a62632137dc84d25a91e7746f55f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.4"
   crypto:
     dependency: transitive
     description:
@@ -316,6 +332,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.5
+  connectivity_plus: ^5.0.1
   device_info_plus: 8.2.2
   geolocator: ^10.0.0
   intl: ^0.18.0


### PR DESCRIPTION
Implemented a new widget called 'ConnectionStateMonitor' that listens to the network connection status. This widget is designed to automatically resume any pending downloads once the network connection is restored.
