### PR TITLE
TICKET-T-20560: Setting code signing to false for pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .history
 .svn/
 .env/
+build.sh
+export-distribution.plist
 
 # IntelliJ related
 *.iml

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -52,6 +52,10 @@ post_install do |installer|
         'PERMISSION_LOCATION=1',
         'PERMISSION_NOTIFICATIONS=1'
         ]
+      config.build_settings["CODE_SIGNING_ALLOWED"] = 'NO'
+      config.build_settings["CODE_SIGNING_REQUIRED"] = 'NO'
+      config.build_settings["PROVISIONING_PROFILE"] = ''
+      config.build_settings["PROVISIONING_PROFILE_SPECIFIER"] = ''
       end
   end
 end


### PR DESCRIPTION
The dependencies need not be signed in the iOS builds hence explicitly added setting to not sign the pods.