### PR TITLE
TICKET-T-19204:RefApp Support clear prefetched cache and map persistent storage.

### DIFF
--- a/lib/download_maps/download_maps_screen.dart
+++ b/lib/download_maps/download_maps_screen.dart
@@ -87,7 +87,7 @@ class _DownloadMapsScreenState extends State<DownloadMapsScreen> {
               PopupMenuButton(
                 icon: Icon(Icons.menu),
                 onSelected: _menuActionHandler,
-                itemBuilder: (BuildContext bc) {
+                itemBuilder: (_) {
                   return [
                     PopupMenuItem(
                       child: Text(AppLocalizations.of(context)!.clearPrefetchedCache),

--- a/lib/download_maps/map_loader_controller.dart
+++ b/lib/download_maps/map_loader_controller.dart
@@ -288,23 +288,14 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
   }
 
   /// Clear persisted map data
-  Future<void> clearPersistentMapStorage() async {
-    final Completer<void> completer = Completer<void>();
-
-    void callback(MapLoaderError? error) {
-      if (error != null) {
-        completer.completeError(error);
-      } else {
-        completer.complete();
-      }
-    }
-
-    _mapDownloader!.clearPersistentMapStorage(callback);
-    return completer.future;
-  }
+  Future<void> clearPersistentMapStorage() async => _onCallback(_mapDownloader!.clearPersistentMapStorage);
 
   /// Clear app cache
   Future<void> clearAppCache() async {
+    return _onCallback(SDKCache.fromSdkEngine(SDKNativeEngine.sharedInstance!).clearAppCache);
+  }
+
+  Future<void> _onCallback(Function callbackFunction) {
     final Completer<void> completer = Completer<void>();
 
     void callback(MapLoaderError? error) {
@@ -315,7 +306,7 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
       }
     }
 
-    SDKCache.fromSdkEngine(SDKNativeEngine.sharedInstance!).clearAppCache(callback);
+    callbackFunction(callback);
     return completer.future;
   }
 

--- a/lib/download_maps/map_loader_controller.dart
+++ b/lib/download_maps/map_loader_controller.dart
@@ -287,6 +287,38 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
     return newCatalogs?.isNotEmpty ?? false;
   }
 
+  /// Clear persisted map data
+  Future<void> clearPersistentMapStorage() async {
+    final Completer<void> completer = Completer<void>();
+
+    void callback(MapLoaderError? error) {
+      if (error != null) {
+        completer.completeError(error);
+      } else {
+        completer.complete();
+      }
+    }
+
+    _mapDownloader!.clearPersistentMapStorage(callback);
+    return completer.future;
+  }
+
+  /// Clear app cache
+  Future<void> clearAppCache() async {
+    final Completer<void> completer = Completer<void>();
+
+    void callback(MapLoaderError? error) {
+      if (error != null) {
+        completer.completeError(error);
+      } else {
+        completer.complete();
+      }
+    }
+
+    SDKCache.fromSdkEngine(SDKNativeEngine.sharedInstance!).clearAppCache(callback);
+    return completer.future;
+  }
+
   @override
   void onCatalogUpdateComplete(MapLoaderError? error) {
     if (error != null && error != MapLoaderError.operationCancelled) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,6 +67,14 @@
   "@carShuttleTrain": {
     "description": "Avoid road feature name for route preferences"
   },
+  "clearPersistentMapStorage": "Clear Persistent Map Storage",
+  "@clearPersistentMapStorage": {
+    "description": "Text for clear Persistent Map Storage action"
+  },
+  "clearPrefetchedCache": "Clear Prefetched Cache",
+  "@clearPrefetchedCache": {
+    "description": "Text for clear Prefetched Cache action"
+  },
   "consentDenied": "Revoked",
   "@consentDenied": {
     "description": "Text for denied consent"


### PR DESCRIPTION
Implemented a menu on the download maps screen, allowing users to 'clear both prefetched cache' and 'persistent map storage'