### PR TITLE
Switch HereMap to use texture view render mode

### DIFF
--- a/lib/landing_screen.dart
+++ b/lib/landing_screen.dart
@@ -110,6 +110,9 @@ class _LandingScreenState extends State<LandingScreen> with Positioning, Widgets
 
   @override
   Widget build(BuildContext context) {
+    final HereMapOptions options = HereMapOptions()
+      ..initialBackgroundColor = Theme.of(context).colorScheme.background;
+    options.renderMode = MapRenderMode.texture;
     return ConnectionStateMonitor(
       mapLoaderController: Provider.of<MapLoaderController>(context, listen: false),
       child: Consumer2<AppPreferences, CustomMapStyleSettings>(
@@ -119,6 +122,7 @@ class _LandingScreenState extends State<LandingScreen> with Positioning, Widgets
             children: [
               HereMap(
                 key: _hereMapKey,
+                options: options,
                 onMapCreated: _onMapCreated,
               ),
               _buildMenuButton(),

--- a/lib/navigation/navigation_screen.dart
+++ b/lib/navigation/navigation_screen.dart
@@ -170,6 +170,7 @@ class _NavigationScreenState extends State<NavigationScreen>
     PreferredSize? topBarWidget = _buildTopBar(context);
     double topOffset = MediaQuery.of(context).padding.top - UIStyle.popupsBorderRadius;
     final HereMapOptions options = HereMapOptions()..initialBackgroundColor = Theme.of(context).colorScheme.background;
+    options.renderMode = MapRenderMode.texture;
     return PopScope(
       child: Scaffold(
         resizeToAvoidBottomInset: false,

--- a/lib/routing/route_details_screen.dart
+++ b/lib/routing/route_details_screen.dart
@@ -217,6 +217,9 @@ class _RouteDetailsScreenState extends State<RouteDetailsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final HereMapOptions options = HereMapOptions()
+      ..initialBackgroundColor = Theme.of(context).colorScheme.background;
+    options.renderMode = MapRenderMode.texture;
     return PopScope(
       canPop: !_hasBeenZoomedToManeuver,
       onPopInvoked: (_) {
@@ -290,6 +293,7 @@ class _RouteDetailsScreenState extends State<RouteDetailsScreen> {
           padding: EdgeInsets.only(bottom: _mapHeight ?? 0),
           child: HereMap(
             key: _mapKey,
+            options: options,
             onMapCreated: (HereMapController mapController) {
               _hereMapController = mapController;
               CustomMapStyleSettings customMapStyleSettings = Provider.of<CustomMapStyleSettings>(

--- a/lib/routing/routing_screen.dart
+++ b/lib/routing/routing_screen.dart
@@ -151,6 +151,7 @@ class _RoutingScreenState extends State<RoutingScreen> with TickerProviderStateM
   @override
   Widget build(BuildContext context) {
     final HereMapOptions options = HereMapOptions()..initialBackgroundColor = Theme.of(context).colorScheme.background;
+    options.renderMode = MapRenderMode.texture;
     return Stack(
       children: [
         Scaffold(

--- a/lib/search/search_results_screen.dart
+++ b/lib/search/search_results_screen.dart
@@ -99,6 +99,7 @@ class _SearchResultsScreenState extends State<SearchResultsScreen> with TickerPr
   Widget build(BuildContext context) {
     final HereMapOptions options = HereMapOptions()
       ..initialBackgroundColor = Theme.of(context).colorScheme.background;
+    options.renderMode = MapRenderMode.texture;
     return DefaultTabController(
       length: widget.places.length,
       child: PopScope(


### PR DESCRIPTION
During testing a bug was discovered while using the app where a grey and
non-reactive map view got displayed from time to time. It turns out with the
HereMap options set to MapRenderMode.texture this issue is no longer happening.
The performance impact is negligible.