### PR TITLE
TICKET-T-3931:RefApp: Improved display of error names in messages

### DIFF
--- a/lib/common/extensions/error_handling/map_loader_error_extension.dart
+++ b/lib/common/extensions/error_handling/map_loader_error_extension.dart
@@ -59,6 +59,6 @@ extension MapLoaderErrorExtension on MapLoaderError {
         break;
     }
 
-    return '$message (${index})';
+    return '$message ($name)';
   }
 }

--- a/lib/common/extensions/error_handling/routing_error_extension.dart
+++ b/lib/common/extensions/error_handling/routing_error_extension.dart
@@ -17,8 +17,8 @@
  * License-Filename: LICENSE
  */
 
-import 'package:here_sdk/routing.dart' as Routing;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:here_sdk/routing.dart' as Routing;
 
 extension RoutingErrorExtension on Routing.RoutingError {
   String errorMessage(AppLocalizations localized) {
@@ -53,6 +53,6 @@ extension RoutingErrorExtension on Routing.RoutingError {
       default:
         message = localized.errorRoutingFailedPleaseTryAgain;
     }
-    return message;
+    return '$message ($name)';
   }
 }

--- a/lib/common/extensions/error_handling/search_error_extension.dart
+++ b/lib/common/extensions/error_handling/search_error_extension.dart
@@ -17,40 +17,46 @@
  * License-Filename: LICENSE
  */
 
-import 'package:here_sdk/search.dart' show SearchError;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:here_sdk/search.dart' show SearchError;
 
 extension SearchErrorExtension on SearchError {
   String? errorMessage(AppLocalizations localized) {
+    String? message;
     switch (this) {
       case SearchError.operationCancelled:
       case SearchError.noResultsFound:
-        return null;
+        message = null;
 
       case SearchError.authenticationFailed:
       case SearchError.forbidden:
-        return localized.errorAuthenticationFailed;
+        message = localized.errorAuthenticationFailed;
 
       case SearchError.maxItemsOutOfRange:
       case SearchError.invalidParameter:
       case SearchError.queryTooLong:
       case SearchError.filterTooLong:
-        return localized.errorNoResultFound;
+        message = localized.errorNoResultFound;
 
       case SearchError.parsingError:
       case SearchError.exceededUsageLimit:
       case SearchError.operationFailed:
-        return localized.errorSearchFailed;
+        message = localized.errorSearchFailed;
 
       case SearchError.httpError:
       case SearchError.serverUnreachable:
       case SearchError.offline:
       case SearchError.proxyAuthenticationFailed:
       case SearchError.proxyServerUnreachable:
-        return localized.errorNetworkIssueOccurred;
+        message = localized.errorNetworkIssueOccurred;
 
       default:
-        return localized.errorSearchFailedPleaseTryAgain;
+        message = localized.errorSearchFailedPleaseTryAgain;
     }
+
+    if (message != null) {
+      return '$message ($name)';
+    }
+    return null;
   }
 }


### PR DESCRIPTION
We have improved the display of errors in toast messages by including the error names for MapLoader, Routing, and Search errors.