### PR TITLE
Fix: refresh UI after clearing persistent map storage

### DIFF
--- a/lib/download_maps/map_loader_controller.dart
+++ b/lib/download_maps/map_loader_controller.dart
@@ -293,7 +293,10 @@ class MapLoaderController extends ChangeNotifier implements MapCatalogUpdateList
   }
 
   /// Clear persisted map data
-  Future<void> clearPersistentMapStorage() async => _onCallback(_mapDownloader!.clearPersistentMapStorage);
+  Future<void> clearPersistentMapStorage() async {
+    await _onCallback(_mapDownloader!.clearPersistentMapStorage);
+    notifyListeners();
+  }
 
   /// Clear app cache
   Future<void> clearAppCache() async {


### PR DESCRIPTION
Ensures UI reflects changes immediately after clearing downloaded maps. Previously, the view wasn't updated until navigating away and returning.