### PR TITLE
Add border radius to MenuButton’s InkWell

### DIFF
--- a/lib/landing_screen.dart
+++ b/lib/landing_screen.dart
@@ -185,6 +185,7 @@ class _LandingScreenState extends State<LandingScreen> with Positioning, Widgets
             borderRadius: BorderRadius.circular(UIStyle.popupsBorderRadius),
             elevation: 2,
             child: InkWell(
+              borderRadius: BorderRadius.circular(UIStyle.popupsBorderRadius),
               child: Padding(
                 padding: EdgeInsets.all(UIStyle.contentMarginMedium),
                 child: Icon(


### PR DESCRIPTION
Apply border radius to InkWell in MenuButton on the landing screen

This ensures visual consistency by matching the border radius of the parent container, enhancing the user experience.

Signed-off-by: Jarosław Gil <zafahix@gmail.com>