### PR TITLE
Add tap feedback to option button in place details popup

### DIFF
--- a/lib/search/place_details_popup.dart
+++ b/lib/search/place_details_popup.dart
@@ -264,33 +264,37 @@ Widget _buildOptionButton(BuildContext context, Widget icon, String title, VoidC
     SimpleDialogOption(
       padding: EdgeInsets.zero,
       child: Material(
+        color: Colors.transparent,
         borderRadius: BorderRadius.circular(UIStyle.bigButtonHeight),
-        child: Container(
-          height: UIStyle.bigButtonHeight,
-          child: Padding(
-            padding: EdgeInsets.only(
-              left: UIStyle.contentMarginLarge,
-              right: UIStyle.contentMarginLarge,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                icon,
-                Container(
-                  width: UIStyle.contentMarginMedium,
-                ),
-                Text(
-                  title,
-                  style: TextStyle(
-                    fontSize: UIStyle.bigFontSize,
-                    fontWeight: FontWeight.bold,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(UIStyle.bigButtonHeight),
+          onTap: onPressed,
+          child: Container(
+            height: UIStyle.bigButtonHeight,
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: UIStyle.contentMarginLarge,
+                right: UIStyle.contentMarginLarge,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  icon,
+                  Container(
+                    width: UIStyle.contentMarginMedium,
                   ),
-                ),
-              ],
+                  Text(
+                    title,
+                    style: TextStyle(
+                      fontSize: UIStyle.bigFontSize,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
-      onPressed: onPressed,
     );


### PR DESCRIPTION
Wraps the option button in an InkWell to provide visual feedback on tap.
This improves the user experience by making interactions feel more responsive and intuitive.

Signed-off-by: Jarosław Gil <zafahix@gmail.com>
